### PR TITLE
Vitestのカバレッジレポート出力時のエラー解消

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,15 +11,16 @@ declare module "@remix-run/node" {
 
 export default defineConfig({
   plugins: [
-    remix({
-      future: {
-        v3_fetcherPersist: true,
-        v3_relativeSplatPath: true,
-        v3_throwAbortReason: true,
-        v3_singleFetch: true,
-        v3_lazyRouteDiscovery: true,
-      },
-    }),
+    !process.env.VITEST &&
+      remix({
+        future: {
+          v3_fetcherPersist: true,
+          v3_relativeSplatPath: true,
+          v3_throwAbortReason: true,
+          v3_singleFetch: true,
+          v3_lazyRouteDiscovery: true,
+        },
+      }),
     tsconfigPaths(),
   ],
   test: {


### PR DESCRIPTION
## 概要
カバレッジレポート出力時の以下のエラーを解消する。
```
close timed out after 10000ms
Tests closed successfully but something prevents Vite server from exiting
You can try to identify the cause by enabling "hanging-process" reporter. See https://vitest.dev/config/#reporter
```

## 修正内容
- Vitest実行時は、Remixのプラグインを使わないように修正

## 備考
- https://remix.run/docs/en/main/guides/vite#plugin-usage-with-other-vite-based-tools-eg-vitest-storybook

> The Remix Vite plugin is only intended for use in your application's development server and production builds. While there are other Vite-based tools such as Vitest and Storybook that make use of the Vite config file, the Remix Vite plugin has not been designed for use with these tools. We currently recommend excluding the plugin when used with other Vite-based tools.